### PR TITLE
Improve the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 USER etheno
-RUN git clone https://github.com/trailofbits/echidna.git
-WORKDIR /home/etheno/echidna
-RUN stack upgrade && stack setup && stack install --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 WORKDIR /home/etheno
+RUN git clone https://github.com/trailofbits/echidna.git && \
+    cd echidna && \
+    stack upgrade && \
+    stack setup && \
+    stack install --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib && \
+    stack purge && \
+    cd .. && \
+    rm -rf .stack echidna
 
 # END Install Echidna
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,28 @@
 FROM ubuntu:18.04
 MAINTAINER Evan Sultanik
 
-RUN apt-get -y update
+RUN apt-get update && apt-get install -y \
+    npm \
+    bash-completion \
+    sudo \
+&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install -y npm bash-completion sudo
-
-RUN npm install -g ganache-cli truffle
+RUN npm install -g ganache-cli truffle && npm cache clean
 
 # BEGIN Requirements for Manticore:
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-pip git
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    git \
+    build-essential \
+    software-properties-common \
+&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install -y build-essential software-properties-common && \
-    add-apt-repository -y ppa:ethereum/ethereum && \
+RUN add-apt-repository -y ppa:ethereum/ethereum && \
     apt-get update && \
-    apt-get install -y solc ethereum
+    apt-get install -y solc ethereum \
+&& rm -rf /var/lib/apt/lists/*
 
 # END Requirements for Manticore
 
@@ -30,10 +38,18 @@ ENV LANG C.UTF-8
 # BEGIN Install Echidna
 
 USER root
-RUN apt-get install -y cmake curl wget libgmp-dev libssl-dev libbz2-dev libreadline-dev software-properties-common locales-all locales libsecp256k1-dev python3-setuptools
+WORKDIR /root
+RUN apt-get update && apt-get install -y \
+    cmake curl wget libgmp-dev libssl-dev libbz2-dev libreadline-dev \
+    software-properties-common locales-all locales libsecp256k1-dev \
+    python3-setuptools \
+&& rm -rf /var/lib/apt/lists/*
 COPY docker/install-libff.sh .
 RUN ./install-libff.sh && rm ./install-libff.sh
-RUN curl -sSL https://get.haskellstack.org/ | sh
+RUN apt-get update && \
+    curl -sSL https://get.haskellstack.org/ | sh && \
+    rm -rf /var/lib/apt/lists/*
+
 USER etheno
 RUN git clone https://github.com/trailofbits/echidna.git
 WORKDIR /home/etheno/echidna
@@ -45,7 +61,9 @@ WORKDIR /home/etheno
 USER root
 
 # Install Parity
-RUN apt-get install -y libudev-dev
+RUN apt-get update && \
+    apt-get install -y libudev-dev && \
+    rm -rf /var/lib/apt/lists/*
 RUN curl https://get.parity.io -L | bash
 
 # Allow passwordless sudo for etheno

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN git clone https://github.com/trailofbits/echidna.git && \
 # END Install Echidna
 
 USER root
+WORKDIR /root
 
 # Install Parity
 RUN apt-get update && \
@@ -74,27 +75,16 @@ RUN curl https://get.parity.io -L | bash
 # Allow passwordless sudo for etheno
 RUN echo 'etheno ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
-RUN chown -R etheno:etheno /home/etheno/
-
 USER etheno
+WORKDIR /home/etheno
 
-RUN mkdir -p /home/etheno/etheno/etheno
+COPY --chown=etheno:etheno LICENSE setup.py etheno/
+COPY --chown=etheno:etheno etheno/*.py etheno/etheno/
+RUN cd etheno && \
+    pip3 install --no-cache-dir --user '.[manticore]' && \
+    cd .. && \
+    rm -rf etheno
 
-COPY LICENSE /home/etheno/etheno
-COPY setup.py /home/etheno/etheno
-
-COPY etheno/*.py /home/etheno/etheno/etheno/
-
-RUN mkdir -p /home/etheno/examples
-COPY examples /home/etheno/examples/
-
-RUN cd etheno && pip3 install --user '.[manticore]'
-
-USER root
-
-RUN chown -R etheno:etheno /home/etheno/etheno
-RUN chown -R etheno:etheno /home/etheno/examples
-
-USER etheno
+COPY --chown=etheno:etheno examples examples/
 
 CMD ["/bin/bash"]

--- a/docker/install-libff.sh
+++ b/docker/install-libff.sh
@@ -21,3 +21,4 @@ mkdir build
 cd build
 CXXFLAGS="-fPIC $CXXFLAGS" cmake $ARGS ..
 make && sudo make install
+cd ../.. && rm -rf libff


### PR DESCRIPTION
The main cause of the large size of eth-security-toolbox docker image is etheno
docker image size. This pull request improves etheno's Dockerfile to produce a
smaller image, as a prerequisite for solving https://github.com/crytic/eth-security-toolbox/issues/5