### PR TITLE
Other minor Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:18.04
 MAINTAINER Evan Sultanik
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     npm \
+    ca-certificates \
     bash-completion \
     sudo \
 && rm -rf /var/lib/apt/lists/*
@@ -11,8 +12,9 @@ RUN npm install --production -g ganache-cli truffle && npm cache clean
 
 # BEGIN Requirements for Manticore:
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
     python3 \
+    libpython3-dev \
     python3-pip \
     git \
     build-essential \
@@ -21,7 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 
 RUN add-apt-repository -y ppa:ethereum/ethereum && \
     apt-get update && \
-    apt-get install -y solc ethereum \
+    apt-get install -y --no-install-recommends solc ethereum \
 && rm -rf /var/lib/apt/lists/*
 
 # END Requirements for Manticore
@@ -39,8 +41,8 @@ ENV LANG C.UTF-8
 
 USER root
 WORKDIR /root
-RUN apt-get update && apt-get install -y \
-    cmake curl wget libgmp-dev libssl-dev libbz2-dev libreadline-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake curl wget libgmp-dev libssl1.0-dev libbz2-dev libreadline-dev \
     software-properties-common locales-all locales libsecp256k1-dev \
     python3-setuptools \
 && rm -rf /var/lib/apt/lists/*
@@ -68,7 +70,7 @@ WORKDIR /root
 
 # Install Parity
 RUN apt-get update && \
-    apt-get install -y libudev-dev && \
+    apt-get install -y --no-install-recommends libudev-dev && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://get.parity.io -L | bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
 && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g ganache-cli truffle && npm cache clean
+RUN npm install --production -g ganache-cli truffle && npm cache clean
 
 # BEGIN Requirements for Manticore:
 

--- a/docker/install-libff.sh
+++ b/docker/install-libff.sh
@@ -5,8 +5,8 @@ set -eux
 if ls /usr/local/lib | grep -q libff; then exit 0; fi
 
 git clone https://github.com/scipr-lab/libff --recursive
-git submodule init && git submodule update
 cd libff
+git submodule init && git submodule update
 ARGS="-DWITH_PROCPS=OFF"
 CXXFLAGS=""
 if [ "$(uname)" = "Darwin" ]; then


### PR DESCRIPTION
Following up on https://github.com/crytic/eth-security-toolbox/issues/5, this PR continues slimming down the etheno Docker image. These changes reduce `docker images` size by another ~70M.