### PR TITLE
Pin manticore, web3 and rlp versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
         'setuptools'
     ],
     extras_require={
-        'manticore': ['manticore>=0.2.2,<0.3.6']
+        # manticore 0.3.6 causes logging errors. See crytic/etheno#80
+        # rlp<3 is needed to stay compatible with manticore
+        'manticore': ['manticore>=0.2.2,<0.3.6', 'rlp<3']
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
         'ptyprocess',
         'pysha3>=1.0.2',
         'flask>=1.0.2',
-        'web3',
+        # web3 3.16.3 and earlier use the older, deprecated `ethereum-*`
+        # libraries, which throw a deprecation warning when running etheno
+        'web3>=3.16.4',
         # The following two requirements are for our fork of `keyfile.py`,
         # but they should already be satisfied by the `web3` requirement
         'cytoolz>=0.9.0,<1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'setuptools'
     ],
     extras_require={
-        'manticore': ['manticore>=0.2.2']
+        'manticore': ['manticore>=0.2.2,<0.3.6']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This pins the following dependencies:
* `web3>=3.16.4`: earlier versions depend on `ethereum-*` instead of `eth-*`. This causes etheno to fail with a deprecation notice.
* `manticore>=0.2.2,<0.3.6`. Manticore 0.3.6 suffers from #80 
* `rlp<3` to avoid installing an incompatible version of rlp when using manticore.