### PR TITLE
Modify geth flags (fixes #88, #90)

### DIFF
--- a/etheno/genesis.py
+++ b/etheno/genesis.py
@@ -119,8 +119,10 @@ DEFAULT_PRIVATE_KEYS = [0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0
 
 def make_accounts(num_accounts, default_balance = None):
     ret = []
+    if not num_accounts:
+        raise ValueError("No accounts passed in genesis.json")
     if num_accounts > len(DEFAULT_PRIVATE_KEYS):
-        raise Exception('TODO: Too many accounts')
+        raise ValueError('TODO: Too many accounts')
     for i in range(num_accounts):
         acct = w3.eth.account.from_key(DEFAULT_PRIVATE_KEYS[i])
         ret.append(Account(address=int(acct.address, 16), private_key=int(acct.privateKey.hex(), 16), balance=default_balance))

--- a/etheno/utils.py
+++ b/etheno/utils.py
@@ -41,6 +41,8 @@ def decode_hex(data: Optional[str]) -> Optional[bytes]:
 
 
 def decode_value(v: Union[str, int]) -> int:
+    if v is None:
+        return 0
     if isinstance(v, int):
         return v
     elif v.startswith('0x') or (frozenset(['a', 'b', 'c', 'd', 'e', 'f']) & frozenset(v)):
@@ -92,7 +94,7 @@ def find_open_port(starting_port: int = 1025) -> int:
 
 def clear_directory(path: str):
     """
-    Deletes the contents of a directory, but not the directory itself. 
+    Deletes the contents of a directory, but not the directory itself.
     This is safe to use on symlinked directories.
     Symlinks will be deleted, but the files and directories they point to will not be deleted.
     If `path` itself is a symlink, the symlink will be deleted.


### PR DESCRIPTION
This PR modifies geth invocation flags to allow this to run in newer versions. Old functionality allowing unlocking accounts with HTTP is now disabled, so the default flags for invoking geth should provision for this, and most likely the current logic of etheno needs changes in a few more places. We could allow users to specify arbitrary geth flags via the etheno cli, however looking for feedback from the maintainers on what is the best way to add this, and what other points / functionality need addressing as part of this PR.