### PR TITLE
Drop rusty-rlp from dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Publish Docker
 on:
   push:
-    branches: [master]
+    branches: [master, docker-build]
     tags:
       - '*'
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Publish Docker
 on:
   push:
-    branches: [master, docker-build]
+    branches: [master]
     tags:
       - '*'
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Unreleased](https://github.com/trailofbits/etheno/compare/v0.3.0...HEAD)
+## [Unreleased](https://github.com/trailofbits/etheno/compare/v0.3.2...HEAD)
 
-## 0.3.0 - 2022-07-08
+## 0.3.2 - 2022-11-01
+
+### Fixed
+- Dropped `rusty-rlp` dependency so that ARM Docker builds work as expected during QEMU emulation
+
+## 0.3.1 - 2022-11-01
 
 ### Changed
 - We are now using `ganache` instead of `ganache-cli` for running Ganache

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-pip \
     python3-setuptools
 
-# Needed for rusty-rlp wheel
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.62.1
-ENV PATH="/root/.cargo/bin:${PATH}"
-
 RUN --mount=type=bind,target=/etheno \
     cd /etheno && \
     pip3 install --no-cache-dir --upgrade pip setuptools && \
     pip3 wheel --no-cache-dir -w /wheels \
-    https://github.com/cburgdorf/rusty-rlp/archive/refs/tags/0.1.15.tar.gz \
     .
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-setuptools
 
 # Needed for rusty-rlp wheel
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.62.1
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN --mount=type=bind,target=/etheno \

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description="Etheno is a JSON RPC multiplexer, differential fuzzer, and test framework integration tool.",
     url="https://github.com/trailofbits/etheno",
     author="Trail of Bits",
-    version="0.3.1",
+    version="0.3.2",
     packages=find_packages(),
     python_requires=">=3.7",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,6 @@ setup(
         "eth-rlp<0.3.0",
         "setuptools",
     ],
-    # rusty-rlp==0.1.15 has to be downloaded as a tarball
-    dependency_links=[
-        "https://github.com/cburgdorf/rusty-rlp/archive/refs/tags/0.1.15.tar.gz"
-    ],
     entry_points={"console_scripts": ["etheno = etheno.__main__:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
We do not appear to use it, and it is currently breaking the ARM docker builds, due to `cargo metadata` crashes in QEMU emulation.